### PR TITLE
hwc_front banner

### DIFF
--- a/docroot/sites/all/modules/hwc/hwc_homepage/hwc_homepage.features.fe_block_settings.inc
+++ b/docroot/sites/all/modules/hwc/hwc_homepage/hwc_homepage.features.fe_block_settings.inc
@@ -136,10 +136,10 @@ function hwc_homepage_default_fe_block_settings() {
     'roles' => array(),
     'themes' => array(
       'hwc_frontend' => array(
-        'region' => 'header',
+        'region' => 'content',
         'status' => 1,
         'theme' => 'hwc_frontend',
-        'weight' => 0,
+        'weight' => -58,
       ),
       'seven' => array(
         'region' => '',

--- a/docroot/sites/all/modules/hwc/hwc_homepage/hwc_homepage.features.inc
+++ b/docroot/sites/all/modules/hwc/hwc_homepage/hwc_homepage.features.inc
@@ -67,7 +67,7 @@ function hwc_homepage_fe_nodequeue_export_fields() {
 function hwc_homepage_node_info() {
   $items = array(
     'frontpage_slider' => array(
-      'name' => t('Frontpage Slider'),
+      'name' => t('Frontpage Banner'),
       'base' => 'node_content',
       'description' => t('Frontpage slider content'),
       'has_title' => '1',

--- a/docroot/sites/all/modules/hwc/hwc_homepage/hwc_homepage.views_default.inc
+++ b/docroot/sites/all/modules/hwc/hwc_homepage/hwc_homepage.views_default.inc
@@ -106,7 +106,9 @@ function hwc_homepage_views_default_views() {
   $handler->display->display_options['cache']['type'] = 'none';
   $handler->display->display_options['query']['type'] = 'views_query';
   $handler->display->display_options['exposed_form']['type'] = 'basic';
-  $handler->display->display_options['pager']['type'] = 'none';
+  $handler->display->display_options['pager']['type'] = 'some';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '1';
+  $handler->display->display_options['pager']['options']['offset'] = '0';
   $handler->display->display_options['style_plugin'] = 'default';
   $handler->display->display_options['style_options']['default_row_class'] = FALSE;
   $handler->display->display_options['style_options']['row_class_special'] = FALSE;
@@ -147,6 +149,7 @@ function hwc_homepage_views_default_views() {
   $handler->display->display_options['fields']['title_field']['field'] = 'title_field';
   $handler->display->display_options['fields']['title_field']['label'] = '';
   $handler->display->display_options['fields']['title_field']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['title_field']['element_class'] = 'banner_title';
   $handler->display->display_options['fields']['title_field']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['title_field']['link_to_entity'] = 0;
   /* Field: Content: Image */
@@ -159,6 +162,7 @@ function hwc_homepage_views_default_views() {
 <div class="views-field-title"><span>[title_field]</span></div>
 [field_image]
 </a>';
+  $handler->display->display_options['fields']['field_image']['element_class'] = 'banner_image';
   $handler->display->display_options['fields']['field_image']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['field_image']['click_sort_column'] = 'fid';
   $handler->display->display_options['fields']['field_image']['settings'] = array(
@@ -170,6 +174,7 @@ function hwc_homepage_views_default_views() {
   $handler->display->display_options['fields']['body']['table'] = 'field_data_body';
   $handler->display->display_options['fields']['body']['field'] = 'body';
   $handler->display->display_options['fields']['body']['label'] = '';
+  $handler->display->display_options['fields']['body']['element_class'] = 'banner_more_button';
   $handler->display->display_options['fields']['body']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['body']['type'] = 'smart_trim_format';
   $handler->display->display_options['fields']['body']['settings'] = array(
@@ -178,7 +183,7 @@ function hwc_homepage_views_default_views() {
     'trim_type' => 'words',
     'trim_suffix' => '...',
     'more_link' => '1',
-    'more_text' => 'Read more',
+    'more_text' => '> Find out more',
     'summary_handler' => 'ignore',
     'trim_options' => array(
       'text' => 0,


### PR DESCRIPTION
- repurposed the osha slider to be a banner
--- content type "Frontpage Slider" renamed to "Frontpage Banner"
--- number of banners set to 1
--- moved the banner block in the content with very low weight in order to stay on top

modified feature hwc_homepage 