### PR TITLE
When English is not selected in the Language filter, the section "Oth…

### DIFF
--- a/docroot/sites/all/modules/osha/osha_publication/osha_publication.pages.inc
+++ b/docroot/sites/all/modules/osha/osha_publication/osha_publication.pages.inc
@@ -140,7 +140,7 @@ function osha_publication_menu_publications_search_native($form_state) {
 function osha_publication_menu_publications_search_related($form_state, $native_nids) {
   global $language;
   $ret = array();
-  if (($language->language == 'en') || ($form_state['input']['languages']['en'] !== NULL)) {
+  if (($form_state['input']['languages']['en'] !== NULL)) {
     return $ret;
   }
   $text = hwc_req_param($form_state, 'text');


### PR DESCRIPTION
…er relevant publications in English" appears below the first list.

Does not matter if english is the current language selected for navigating the website.