### PR TITLE
When English is not selected in the Language filter, the section "Oth…

### DIFF
--- a/docroot/sites/all/modules/hwc/hwc_practical_tool/hwc_practical_tool.pages.inc
+++ b/docroot/sites/all/modules/hwc/hwc_practical_tool/hwc_practical_tool.pages.inc
@@ -187,7 +187,7 @@ function hwc_practical_tool_menu_tools_search_native($form_state) {
 function hwc_practical_tool_menu_tools_search_related($form_state, $native_nids) {
   global $language;
   $ret = array();
-  if ($language->language === 'en') {
+  if (($form_state['input']['languages']['en'] !== NULL)) {
     return $ret;
   }
   $text = hwc_req_param($form_state, 'text');


### PR DESCRIPTION
…er relevant practical tools in English" appears below the first list.

Does not matter if english is the current language selected for navigating the website.